### PR TITLE
Let generalization let some specific codes with wrong levels in regions that are lower than the hole level

### DIFF
--- a/crates/atiny-checker/src/lib.rs
+++ b/crates/atiny-checker/src/lib.rs
@@ -64,7 +64,7 @@ fn unify_hole(
             if let MonoType::Hole(oth_ref) = &*other {
                 match oth_ref.get() {
                     Hole::Empty(lvl2) if lvl2 > lvl => {
-                        ref_.get_item().data = Hole::Empty(lvl2);
+                        ref_.get_item().data = Hole::Empty(lvl);
                         oth_ref.fill(hole);
                     }
                     _ => ref_.fill(other),

--- a/crates/atiny-checker/src/lib.rs
+++ b/crates/atiny-checker/src/lib.rs
@@ -164,8 +164,8 @@ impl<'a> Infer<'a, '_> for Expr {
             }
 
             Let(x, e0, e1) => {
-                let ctx = ctx.level_up();
-                let t = e0.infer(ctx.clone())?;
+                let lvl_ctx = ctx.level_up();
+                let t = e0.infer(lvl_ctx.clone())?;
                 let t_generalized = t.generalize(ctx.clone());
 
                 let new_ctx = ctx.extend(x, t_generalized);

--- a/crates/atiny-checker/src/types.rs
+++ b/crates/atiny-checker/src/types.rs
@@ -127,7 +127,7 @@ impl Ref {
         self.0.borrow().data.clone()
     }
 
-    pub fn get_item(&self) -> RefMut<RefItem> {
+    pub fn get_item_mut(&self) -> RefMut<RefItem> {
         self.0.as_ref().borrow_mut()
     }
 }

--- a/crates/atiny-checker/src/util.rs
+++ b/crates/atiny-checker/src/util.rs
@@ -1,4 +1,4 @@
-use std::ops::{ControlFlow, FromResidual, Try};
+use std::fmt::Display;
 
 pub fn format_radix(mut x: usize, radix: usize) -> String {
     let mut result = vec![];
@@ -13,30 +13,11 @@ pub fn format_radix(mut x: usize, radix: usize) -> String {
     format!("'{}", result.into_iter().rev().collect::<String>())
 }
 
-pub enum UnifyResult {
-    Ok,
-    CantUnify,
-    Cyclic,
-}
+#[derive(Debug)]
+pub struct OccursCheck;
 
-impl Try for UnifyResult {
-    type Output = Self;
-    type Residual = Self;
-
-    fn from_output(output: Self::Output) -> Self {
-        output
-    }
-
-    fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
-        match self {
-            Self::Ok => ControlFlow::Continue(self),
-            _ => ControlFlow::Break(Self::Cyclic),
-        }
-    }
-}
-
-impl FromResidual for UnifyResult {
-    fn from_residual(residual: <Self as Try>::Residual) -> Self {
-        residual
+impl Display for OccursCheck {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "found cyclic type of infinite size")
     }
 }

--- a/crates/atiny-parser/src/lib.rs
+++ b/crates/atiny-parser/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![warn(clippy::use_self)]
-#![feature(try_trait_v2)]
 
 pub mod error;
 


### PR DESCRIPTION
This changed is based on this paragraph:

> Just as an assignment may change the owner of an allocated piece of memory, unification may change the level of a free type variable. For example, if ty_x (level 1) and ty_y (level 2) are both free and ty_x is unified with the type TArrow(ty_y,ty_y), the arrow type and its components are exported into region 1, and so the level of ty_y is changed to 1. One may view the above unification as replacing all occurrences of ty_x with TArrow(ty_y,ty_y). Since t_x has a smaller level and may hence occur outside the inner, level-2 let, after the bound-expression of that inner let is type-checked ty_y should not be deallocated. With the updated ty_y level, it won't be. All in all, unifying a free type variable ty_x with t has to update the level of each free type variable ty_y in t to the smallest of ty_y and ty_x levels. Unifying a free type variable with t also has to do the occurs check, which too traverses the type. The two traversals can be merged. The new occurs does the occurs check and updates the levels (..)

of https://okmij.org/ftp/ML/generalization.html